### PR TITLE
Fix incorrect checksum for dfhack

### DIFF
--- a/sha1sums
+++ b/sha1sums
@@ -1,5 +1,5 @@
 a66d56562ffba698198127c8d9a1194a2313c992  downloads/df_34_11_linux.tar.bz2
-c7e7783a1161cce13a1409702af1cc17ed6d2e4c  downloads/dfhack-0.34.11-r3-Linux.tar.gz
+7bcf0bf5fc28d3d896addf6a4e8e53dc3756f46a  downloads/dfhack-0.34.11-r3-Linux.tar.gz
 9d1f917015be2255847d06cf910a779a6bbb230b  downloads/lazy-newbpack-linux-0.5.3-SNAPSHOT-20130822-1652.tar.bz2
 da5ab735f8d6941532f644e4ee3939e2b6b986d6  downloads/Utility_Plugins_v0.35-Windows-0.34.11.r3.zip.zip
 f370d0aab01dc65d32cc1cb38ada0390056b8429  downloads/soundSense_42_186.zip


### PR DESCRIPTION
dfhack has an incorrect checksum, this commit fixes it.
