### PR TITLE
Add dependency on libJPEG 6.2; needed by Stonesense

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ System Requirements
 * LibGLU 1, 32-bit
 * LibGTK 2.0, 32-bit
 * OpenAL 1.2, 32-bit
+* LibJPEG 6.2, 32-bit
 * Git
 * Mercurial (hg)
 * Qt4 Development Libraries including qmake
@@ -48,7 +49,7 @@ The df-lnp-installer script will automatically check your system for the require
 
 The Debian (and possibly Ubuntu) command to install these dependencies is: 
 ```
-sudo apt-get install default-jre libsdl1.2debian:i386 libsdl-image1.2:i386 libsdl-ttf2.0-0:i386 libglu1-mesa:i386 libgtk2.0-0:i386 libopenal1:i386 git mercurial libqt4-dev qt4-qmake wget coreutils tar unzip unrar make gcc patch xterm sed
+sudo apt-get install default-jre libsdl1.2debian:i386 libsdl-image1.2:i386 libsdl-ttf2.0-0:i386 libglu1-mesa:i386 libgtk2.0-0:i386 libopenal1:i386 libjpeg62:i386 git mercurial libqt4-dev qt4-qmake wget coreutils tar unzip unrar make gcc patch xterm sed
 ```
 
 Usage

--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -197,7 +197,15 @@ check_dependencies () {
   if [ -z "$LIBGTK_SO_32_BIT_FILENAME" ]; then
 	MISSING_DEPS="${MISSING_DEPS}libGTK-x11_(32-bit) "
   fi
+
+  # Check for libjpeg62; must be 32-bit (required for Stonesense).
+  local LIBJPEG62_SO="$(/sbin/ldconfig -p | grep -P '^\tlibjpeg.so.62\s' | sed 's/^[>]*> //')"
+  local LIBJPEG62_SO_32_BIT_FILENAME="$(file -L $LIBJPEG62_SO | grep "32-bit" | cut -d: -f1)"
   
+  if [ -z "$LIBJPEG62_SO_32_BIT_FILENAME" ]; then
+	  MISSING_DEPS="${MISSING_DEPS}libJPEG62_(32-bit) "
+  fi
+
   ######
   # Error if the $MISSING_DEPS string contains a value (aka there are missing dependencies).
   ######


### PR DESCRIPTION
Without this library loading the Stonesense plugin fails; the reason why can only be found in the log file.

I wasn't able to actually test the updated Debian command.
