### PR TITLE
Correctly check for and use Qt4's qmake

### DIFF
--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -41,7 +41,7 @@ build_dwarf_therapist () {
   local DWARF_THERAPIST_HG_DIR="$DOWNLOAD_DIR/dwarftherapist"
   
   # Create the makefile.
-  qmake "$DWARF_THERAPIST_HG_DIR" -o "$DWARF_THERAPIST_HG_DIR/Makefile"
+  $qmake "$DWARF_THERAPIST_HG_DIR" -o "$DWARF_THERAPIST_HG_DIR/Makefile"
   
   # Build from the Makefile.
   make -C "$DWARF_THERAPIST_HG_DIR"
@@ -117,10 +117,18 @@ check_dependencies () {
   if [ -z "$(which hg)" ]; then
 	MISSING_DEPS="${MISSING_DEPS}hg "
   fi
-  
+
   # qmake (required for DwarfTherapist)
-  if [ -z "$(which hg)" ]; then
-	MISSING_DEPS="${MISSING_DEPS}qmake "
+  # Also store the name of the qt4 qmake binary for later
+  qmake=""
+  for name in "qmake" "qmake-qt4"; do
+	  if [ -n "$(which $name)" ] && $name -v | grep "Using Qt version 4" > /dev/null; then
+		  qmake=$name
+		  break
+	  fi
+  done
+  if [ -z $qmake ]; then
+	MISSING_DEPS="${MISSING_DEPS}qmake_qt4 "
   fi
   
   # make (required for DwarfTherapist)

--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -41,7 +41,7 @@ build_dwarf_therapist () {
   local DWARF_THERAPIST_HG_DIR="$DOWNLOAD_DIR/dwarftherapist"
   
   # Create the makefile.
-  $qmake "$DWARF_THERAPIST_HG_DIR" -o "$DWARF_THERAPIST_HG_DIR/Makefile"
+  $(find_qmake_qt4) "$DWARF_THERAPIST_HG_DIR" -o "$DWARF_THERAPIST_HG_DIR/Makefile"
   
   # Build from the Makefile.
   make -C "$DWARF_THERAPIST_HG_DIR"
@@ -61,6 +61,15 @@ bugfix_all () {
   fix_phoebus_missing_mouse_png
   fix_vanilla_df_openal_issue
   fix_vanilla_df_lnp_settings_not_applied_by_default
+}
+
+find_qmake_qt4 () {
+  for name in "qmake" "qmake-qt4"; do
+	if [ -n "$(which $name)" ] && [ $($name -query QT_VERSION | cut -d . -f 1) -eq 4 ]; then
+		echo $name
+		break
+	fi
+  done
 }
 
 check_dependencies () {
@@ -119,15 +128,7 @@ check_dependencies () {
   fi
 
   # qmake (required for DwarfTherapist)
-  # Also store the name of the qt4 qmake binary for later
-  qmake=""
-  for name in "qmake" "qmake-qt4"; do
-	  if [ -n "$(which $name)" ] && [ $($name -query QT_VERSION | cut -d . -f 1) -eq 4 ]; then
-		  qmake=$name
-		  break
-	  fi
-  done
-  if [ -z $qmake ]; then
+  if [ -z "$(find_qmake_qt4)" ]; then
 	MISSING_DEPS="${MISSING_DEPS}qmake_qt4 "
   fi
   

--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -122,7 +122,7 @@ check_dependencies () {
   # Also store the name of the qt4 qmake binary for later
   qmake=""
   for name in "qmake" "qmake-qt4"; do
-	  if [ -n "$(which $name)" ] && $name -v | grep "Using Qt version 4" > /dev/null; then
+	  if [ -n "$(which $name)" ] && [ $($name -query QT_VERSION | cut -d . -f 1) -eq 4 ]; then
 		  qmake=$name
 		  break
 	  fi


### PR DESCRIPTION
For some reason, qmake is the Qt 5 version on this machine. Compilation failed because it couldn't find the Qt 4 libraries.

Instead of just using qmake, check if either qmake or qmake or qmake-qt4
exists and uses version 4 of Qt. This affects both the dependency check
and the actual compilation of Dwarf Therapist.

This also generally fixes the dependency check. Previously, it actually
tested for Mercurial a second time.
