### PR TITLE
Don't check ptrace_scope if it isn't compiled in

### DIFF
--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -281,7 +281,12 @@ check_install_dir_contains_df_install () {
 }
 
 check_ptrace_protection () {
-  local PTRACE_PROTECTION="$(cat /proc/sys/kernel/yama/ptrace_scope)"
+  local PTRACE_PROTECTION_FILE="/proc/sys/kernel/yama/ptrace_scope"
+  if [ -e $PTRACE_PROTECTION_FILE ]; then
+	  local PTRACE_PROTECTION="$(cat $PTRACE_PROTECTION_FILE)"
+  else
+	  local PTRACE_PROTECTION="0"
+  fi
   
   if [ "$PTRACE_PROTECTION" = "1" ]; then
 	# Clean up after ourself.


### PR DESCRIPTION
If `CONFIG_YAMA` isn't set in the kernel config at compile time, ptrace protection isn't available and the file in `/proc/sys` doesn't exist. In that case `cat /proc/sys/kernel/yama/ptrace_scope` prints a (harmless) error message.
