### PR TITLE
Fix comparison test when qmake returns "**Unknown**"

### DIFF
--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -104,7 +104,7 @@ bugfix_all () {
 
 find_qmake_qt4 () {
   for name in "qmake" "qmake-qt4"; do
-	if [ -n "$(which $name)" ] && [ $($name -query QT_VERSION | cut -d . -f 1) -eq 4 ]; then
+	if [ -n "$(which $name)" ] && [ $($name -query QT_VERSION | cut -d . -f 1) == 4 ]; then
 		echo $name
 		break
 	fi


### PR DESCRIPTION
When running df-lnp-installer.sh for the first time, I get this error:

> [~/df-lnp-installer]$ ./df-lnp-installer.sh 
> Checking for dependencies...
> ./df-lnp-installer.sh: line 107: [: **Unknown**: integer expression expected
> 
> Where should Dwarf Fortress be installed? [/home/jbecker/bin/Dwarf Fortress]: ^C
> [...]

This comes from the output of "qmake -query QT_VERSION", which can return the string "**Unknown**".  This isn't valid for comparing with "-eq", since that requires numbers, and not strings.
