### PR TITLE
Add Fedora dependencies installation command to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ The Debian (and possibly Ubuntu) command to install these dependencies is:
 sudo apt-get install default-jre libsdl1.2debian:i386 libsdl-image1.2:i386 libsdl-ttf2.0-0:i386 libglu1-mesa:i386 libgtk2.0-0:i386 libopenal1:i386 libjpeg62:i386 git mercurial libqt4-dev qt4-qmake wget coreutils tar unzip unrar make g++ gcc patch xterm sed
 ```
 
+The Fedora command to install these dependencies is:
+```
+sudo yum install java-1.7.0-openjdk gcc gcc-c++ automake libgcc.i686 git cmake glibc-devel.i686 zlib-devel.i686 perl-XML-LibXSLT perl-XML-LibXML mercurial qt.i686 libgcc.i686 qt-devel SDL.i686 SDL_image.i686 SDL_ttf.i686 gtk2.i686 mesa-libGLU.i686 openal-soft.i686 libsndfile.i686 xterm unrar unzip
+```
+
 Usage
 =====
 


### PR DESCRIPTION
Test on Fedora 17 and 18. Should work on 19 and upcoming 20 too.
