### PR TITLE
Update sha1sums

### DIFF
--- a/sha1sums
+++ b/sha1sums
@@ -1,7 +1,7 @@
 a66d56562ffba698198127c8d9a1194a2313c992  downloads/df_34_11_linux.tar.bz2
 7bcf0bf5fc28d3d896addf6a4e8e53dc3756f46a  downloads/dfhack-0.34.11-r3-Linux.tar.gz
 9d1f917015be2255847d06cf910a779a6bbb230b  downloads/lazy-newbpack-linux-0.5.3-SNAPSHOT-20130822-1652.tar.bz2
-5e68e93f7fd5e4301b6050c7b29790c4d59aeabb  downloads/Utility_Plugins_v0.36-Windows-0.34.11.r3.zip.zip
+440335af220c534cc23e9701c7cde0b549f3544c  downloads/Utility_Plugins_v0.36-Windows-0.34.11.r3.zip.zip
 f370d0aab01dc65d32cc1cb38ada0390056b8429  downloads/soundSense_42_186.zip
 f9b7651e88ba6c1cef705e81ae7f794dba90098f  downloads/Phoebus_34_11v01.zip
 bc470cd29f53214c0c59ffec64db93086a470193  downloads/CLA_graphic_set_v15-STANDALONE.rar
@@ -12,4 +12,4 @@ cf3d5a10e9c6417ca67040b85bd166c4e1b6a4a2  downloads/[16x16] Spacefox 34.11v1.0.z
 21dcaa2c5dfff7acba7b95435cf029abfdb52bf7  downloads/JollyBastion34-10v5.zip
 a383d7a61685196ea79a739b74907d46bcb4274a  downloads/Chromafort.zip
 b67a8646170bda602525e2f28d262052e6ef9c85  downloads/DFAnnouncementFilter.zip
-58efd58e2fd6f1858879ea4311e169d5ad5555bc  downloads/Dwarf Therapist.pdf
+5a62072959e8965ab0f37e1ce090630eaa3c94ff  downloads/Dwarf Therapist.pdf


### PR DESCRIPTION
Updated sha1sums to match latest files (as of 6th Jan 2014).

See issues #44 and #16 and #41.

Not sure what a good fix would be long term though - just flag it as a warning rather than a fatal error?
