### PR TITLE
Debug

### DIFF
--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -190,11 +190,6 @@ check_dependencies () {
 		MISSING_DEPS="${MISSING_DEPS}xterm "
 	fi
 
-	# Mercurial (required for DwarfTherapist)
-	if [ -z "$(which hg)" ]; then
-		MISSING_DEPS="${MISSING_DEPS}hg "
-	fi
-
 	# make (required for DwarfTherapist)
 	if [ -z "$(which make)" ]; then
 		MISSING_DEPS="${MISSING_DEPS}make "
@@ -256,6 +251,11 @@ check_dependencies () {
 		# qmake (required for DwarfTherapist)
 		if [ -z "$(find_qmake_qt4)" ]; then
 			MISSING_DEPS="${MISSING_DEPS}qmake_qt4 "
+		fi
+
+		# Mercurial (required for downloading DwarfTherapist from code.google)
+		if [ -z "$(which hg)" ]; then
+			MISSING_DEPS="${MISSING_DEPS}hg "
 		fi
 	fi
 

--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -126,7 +126,7 @@ find_qmake_qt4 () {
 }
 
 find_qmake_qt5 () {
-	for name in "qmake" "qmake-qt5"; do
+	for name in "qmake" "qmake-qt5" "qmake -qt5"; do
 		# If the executable exists...
 		# and its -query QT_VERSION output is "5"...
 		# then return that executable name.

--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -520,7 +520,7 @@ download_all () {
 	# Apps and utilities
 	download_file "http://www.bay12games.com/dwarves/df_34_11_linux.tar.bz2"
 	download_file "http://dethware.org/dfhack/download/dfhack-0.34.11-r3-Linux.tar.gz"
-	download_dffi_file "http://dffd.wimbli.com/download.php?id=7248&f=Utility_Plugins_v0.46-Windows-0.34.11.r3.zip.zip"
+	download_dffi_file "http://dffd.wimbli.com/download.php?id=7248&f=Utility_Plugins_v0.47-Windows-0.34.11.r3.zip.zip"
 	download_file "http://df.zweistein.cz/soundsense/soundSense_42_186.zip"
 	download_file "http://drone.io/bitbucket.org/Dricus/lazy-newbpack/files/target/lazy-newbpack-linux-0.5.3-SNAPSHOT-20130822-1652.tar.bz2"
 	download_dffi_file "http://dffd.wimbli.com/download.php?id=2182&f=Chromafort.zip"

--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -225,7 +225,8 @@ check_dependencies () {
 		MISSING_DEPS_QT5="${MISSING_DEPS_QT5}libQt5Gui "
 	fi
 
-	if [ -z "$(/sbin/ldconfig -p | grep -P '^\tlibQt5Script.so')" ]; then
+	# The space is needed to detect libQt5Script.so and not libQt5Script.so.5
+	if [ -z "$(/sbin/ldconfig -p | grep -P '^\tlibQt5Script.so ')" ]; then
 		MISSING_DEPS_QT5="${MISSING_DEPS_QT5}libQt5Script "
 	fi
 

--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -123,13 +123,13 @@ find_qmake_qt4 () {
 }
 
 find_qmake_qt5 () {
-	for name in "qmake" "qmake-qt5"; do
+	for name in "qmake" "qmake-qt5" "qmake -qt5"; do
 		# If the executable exists...
 		# and its -query QT_VERSION output is "5"...
 		# then return that executable name.
 		if [ -n "$(which $name)" ] && [ "$($name -query QT_VERSION | cut -d . -f 1)" = "5" ]; then
-			#echo $name
-			echo "qmake-qt5"
+			echo $name
+			#echo "qmake-qt5"
 			break
 		fi
 	done

--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -519,7 +519,7 @@ download_all () {
 	# Apps and utilities
 	download_file "http://www.bay12games.com/dwarves/df_34_11_linux.tar.bz2"
 	download_file "http://dethware.org/dfhack/download/dfhack-0.34.11-r3-Linux.tar.gz"
-	download_dffi_file "http://dffd.wimbli.com/download.php?id=7248&f=Utility_Plugins_v0.44-Windows-0.34.11.r3.zip.zip"
+	download_dffi_file "http://dffd.wimbli.com/download.php?id=7248&f=Utility_Plugins_v0.46-Windows-0.34.11.r3.zip.zip"
 	download_file "http://df.zweistein.cz/soundsense/soundSense_42_186.zip"
 	download_file "http://drone.io/bitbucket.org/Dricus/lazy-newbpack/files/target/lazy-newbpack-linux-0.5.3-SNAPSHOT-20130822-1652.tar.bz2"
 	download_dffi_file "http://dffd.wimbli.com/download.php?id=2182&f=Chromafort.zip"

--- a/sha1sums
+++ b/sha1sums
@@ -1,7 +1,7 @@
 a66d56562ffba698198127c8d9a1194a2313c992  downloads/df_34_11_linux.tar.bz2
 7bcf0bf5fc28d3d896addf6a4e8e53dc3756f46a  downloads/dfhack-0.34.11-r3-Linux.tar.gz
 9d1f917015be2255847d06cf910a779a6bbb230b  downloads/lazy-newbpack-linux-0.5.3-SNAPSHOT-20130822-1652.tar.bz2
-3ec47274fe71f02539ec18063cfa2da2da9bd278  downloads/Utility_Plugins_v0.44-Windows-0.34.11.r3.zip.zip
+86177f54506cf22404d1d81241a5494cf5c2b0f9  downloads/Utility_Plugins_v0.46-Windows-0.34.11.r3.zip.zip
 f370d0aab01dc65d32cc1cb38ada0390056b8429  downloads/soundSense_42_186.zip
 f9b7651e88ba6c1cef705e81ae7f794dba90098f  downloads/Phoebus_34_11v01.zip
 bc470cd29f53214c0c59ffec64db93086a470193  downloads/CLA_graphic_set_v15-STANDALONE.rar

--- a/sha1sums
+++ b/sha1sums
@@ -1,7 +1,7 @@
 a66d56562ffba698198127c8d9a1194a2313c992  downloads/df_34_11_linux.tar.bz2
 7bcf0bf5fc28d3d896addf6a4e8e53dc3756f46a  downloads/dfhack-0.34.11-r3-Linux.tar.gz
 9d1f917015be2255847d06cf910a779a6bbb230b  downloads/lazy-newbpack-linux-0.5.3-SNAPSHOT-20130822-1652.tar.bz2
-86177f54506cf22404d1d81241a5494cf5c2b0f9  downloads/Utility_Plugins_v0.46-Windows-0.34.11.r3.zip.zip
+a5bb4f456ae94e5a9e9392d196f4ae3c987803b0  downloads/Utility_Plugins_v0.47-Windows-0.34.11.r3.zip.zip
 f370d0aab01dc65d32cc1cb38ada0390056b8429  downloads/soundSense_42_186.zip
 f9b7651e88ba6c1cef705e81ae7f794dba90098f  downloads/Phoebus_34_11v01.zip
 bc470cd29f53214c0c59ffec64db93086a470193  downloads/CLA_graphic_set_v15-STANDALONE.rar


### PR DESCRIPTION
Should solve several issues :
- issue #65 on Ubuntu.
- issue #63 by updating sha1sums
- issue #64. The script now checks only libQt5Script.so, and raises an error when only libQt5Script.so.5 is installed (libraries provided by different packages).

I also modified the script so that it requires hg only when using the qt4 version of dwarf therapist, since the latest version is downloaded with git.
