### PR TITLE
Quote STARTLNP in desktop file in case spaces in INSTALL_DIR

### DIFF
--- a/df-lnp-installer.sh
+++ b/df-lnp-installer.sh
@@ -386,7 +386,7 @@ create_df_lnp_desktop_file () {
 	local LAUNCHER_FILENAME="dwarf_fortress_lazy_newb_pack.desktop"
 	local LAUNCHER_FULL_PATH="$LAUNCHER_DIR/$LAUNCHER_FILENAME"
 
-	local STARTLNP="$INSTALL_DIR/startlnp"
+	local STARTLNP="\"$INSTALL_DIR/startlnp\""
 	local LOGO="$INSTALL_DIR/DF_LNP_Logo_128.png"
 
 	# Delete any existing, out of date launcher.


### PR DESCRIPTION
The desktop launcher file won't work if there is a space in the Exec line and the default INSTALL_DIR has a space so the STARTLNP variable should definitely be quoted.
